### PR TITLE
feat: add MCP testing scaffold and documentation

### DIFF
--- a/MCP_TEST.md
+++ b/MCP_TEST.md
@@ -1,0 +1,11 @@
+# MCP Testing Guide
+
+This branch contains test data for Grok MCP testing.
+
+## What's Here
+- `tests/setup.ts` - Test scaffold
+- `docs/contributing.md` - Contribution guidelines
+- `MCP_TEST.md` - This file
+
+## Purpose
+This data was seeded to provide realistic test scenarios for evaluating GitHub MCP connector behavior across read and write operations.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,21 @@
+# Contributing to Imagelight
+
+## Getting Started
+1. Fork the repo
+2. Clone your fork
+3. Install dependencies: `bun install`
+4. Create a branch: `git checkout -b feature/your-feature`
+
+## Development
+- Run dev server: `bun dev`
+- Lint: `bun run lint`
+- Type check: `bun run typecheck`
+
+## Pull Request Process
+1. Update documentation if needed
+2. Ensure all checks pass
+3. Request review from maintainer
+4. Squash merge after approval
+
+## Code Style
+We use Biome for linting and formatting. Configuration is in `biome.json`.

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+
+describe("Imagelight Setup", () => {
+  it("should verify environment variables", () => {
+    expect(process.env.NEXT_PUBLIC_SUPABASE_URL).toBeDefined();
+    expect(process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY).toBeDefined();
+  });
+
+  it("should verify database connection", async () => {
+    // TODO: Add Supabase client connection test
+    expect(true).toBe(true);
+  });
+
+  it("should verify auth flow", async () => {
+    // TODO: Add auth integration test
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Adds test scaffold and contribution docs for MCP testing.

## Changes
- `MCP_TEST.md` — Testing guide for MCP operations
- `tests/setup.ts` — Vitest test scaffold with env and auth checks
- `docs/contributing.md` — Contribution guidelines

## Related Issues
Closes #

## Checklist
- [x] Tests added
- [x] Docs updated
- [ ] Lint passes
- [ ] Type check passes